### PR TITLE
Fix code scanning alert no. 27: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
+++ b/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
@@ -97,10 +97,8 @@ public class CommentsCache {
     var jc = JAXBContext.newInstance(Comment.class);
     var xif = XMLInputFactory.newInstance();
 
-    if (webSession.isSecurityEnabled()) {
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // compliant
-    }
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // compliant
 
     var xsr = xif.createXMLStreamReader(new StringReader(xml));
 


### PR DESCRIPTION
Fixes [https://github.com/afernalc73/WebGoat/security/code-scanning/27](https://github.com/afernalc73/WebGoat/security/code-scanning/27)

To fix the problem, we need to ensure that the `XMLInputFactory` is always securely configured to prevent XXE attacks, regardless of the `webSession.isSecurityEnabled()` condition. This involves setting the properties to disable external DTDs and schemas unconditionally.

**Steps to fix:**
1. Remove the conditional check around the security configuration of the `XMLInputFactory`.
2. Ensure that the properties to disable external DTDs and schemas are always set.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
